### PR TITLE
Bump to Electron 35.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativefier",
-    "version": "53.0.3",
+    "version": "53.0.4",
     "description": "Wrap web apps natively",
     "license": "MIT",
     "author": "Goh Jia Hao",
@@ -57,7 +57,7 @@
         "watch": "npx concurrently \"npm:*:watch\""
     },
     "dependencies": {
-        "@electron/asar": "^3.2.4",
+        "@electron/asar": "",
         "axios": "^1.6.0",
         "electron-packager": "^17.1.1",
         "fs-extra": "^11.1.1",
@@ -83,7 +83,7 @@
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "",
         "@typescript-eslint/parser": "",
-        "electron": "35.1.2",
+        "electron": "35.1.5",
         "eslint": "",
         "eslint-config-prettier": "",
         "eslint-plugin-prettier": "",


### PR DESCRIPTION
* Start the process of unpinning shit because npm is cancer and Nativefier is not a BoM product.