### PR TITLE
More tidying up of the fucked dependency chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "engines_README": "Bumping the minimum required Node version? You must bump: 1. package.json -> engines.node, 2. package.json -> devDependencies.@types/node , 3. tsconfig.json -> {target, lib} , 4. .github/workflows/ci.yml -> node-version",
     "engines_READMEforEnginesNode": "Here in engines.node, we require a version as old as possible, for Nativefier to be easily installable using the stock Node.js shipped by conservative Linux distros. It's a balancing act between this, and our own dependencies requiring more a recent Node; as much as possible, try to keep supporting Debian stable; https://packages.debian.org/search?suite=stable&keywords=nodejs",
     "engines": {
-        "node": ">= 16.16.0",
-        "npm": ">= 8.11.0"
+        "node": ">= v22.14",
+        "npm": ">= 11.2"
     },
     "keywords": [
         "desktop",
@@ -22,10 +22,10 @@
     "bin": {
         "nativefier": "lib/cli.js"
     },
-    "homepage": "https://github.com/nativefier/nativefier",
+    "homepage": "https://github.com/majick/nativefier",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/nativefier/nativefier.git"
+        "url": "git+https://github.com/majick/nativefier.git"
     },
     "bugs": {
         "url": "https://github.com/nativefier/nativefier/issues"
@@ -57,9 +57,9 @@
         "watch": "npx concurrently \"npm:*:watch\""
     },
     "dependencies": {
-        "@electron/asar": "^3.2.4",
+        "@electron/asar": "",
         "axios": "^1.6.0",
-        "electron-packager": "^17.1.1",
+        "electron-packager": "",
         "fs-extra": "^11.1.1",
         "gitcloud": "^0.2.4",
         "hasbin": "^1.2.3",
@@ -77,7 +77,7 @@
         "@types/hasbin": "^1.2.0",
         "@types/jest": "^29.5.4",
         "@types/ncp": "^2.0.5",
-        "@types/node": "^20.5.6",
+        "@types/node": "^22.14.0",
         "@types/page-icon": "^0.3.4",
         "@types/tmp": "^0.2.3",
         "@types/yargs": "^17.0.24",
@@ -87,7 +87,7 @@
         "eslint": "",
         "eslint-config-prettier": "",
         "eslint-plugin-prettier": "",
-        "jest": "^29.6.2",
+        "jest": "",
         "playwright": "^1.36.2",
         "prettier": "^3.0.1",
         "rimraf": "^5.0.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,24 +1,28 @@
 import * as path from 'path';
 
+// doooog shiiiiiit
 export const DEFAULT_APP_NAME = 'APP';
+
+// Why in the living fuck do I need these constants? WHY? What do we even DO with them?
 
 // Upgrade both DEFAULT_ELECTRON_VERSION and DEFAULT_CHROME_VERSION together, and
 //   - upgrade app / package.json / "devDependencies" / "electron"
 //   - upgrade       package.json / "devDependencies" / "electron"
 // Doing a *major* upgrade? Read https://github.com/nativefier/nativefier/blob/master/HACKING.md#deps-major-upgrading-electron
-export const DEFAULT_ELECTRON_VERSION = '25.7.0';
+export const DEFAULT_ELECTRON_VERSION = '35.1.5';
 // https://atom.io/download/atom-shell/index.json
 // https://www.electronjs.org/releases/stable
-export const DEFAULT_CHROME_VERSION = '114.0.5735.289';
+export const DEFAULT_CHROME_VERSION = '134.0.6998.179';
 
 // Update each of these periodically
 // https://product-details.mozilla.org/1.0/firefox_versions.json
-export const DEFAULT_FIREFOX_VERSION = '116.0.3';
+export const DEFAULT_FIREFOX_VERSION = '136.0';
 
 // https://en.wikipedia.org/wiki/Safari_version_history
+// Loooooooool
 export const DEFAULT_SAFARI_VERSION = {
-    majorVersion: 16,
-    version: '16.6',
+    majorVersion: 18,
+    version: '18.4',
     webkitVersion: '605.1.15',
 };
 


### PR DESCRIPTION
* also a vague poke at unfucking the shittily-made, overengineered tests
  how in the love of all holy hell do people put up with these overcomplicated shitboxes? It's one thing to have a robust test harness, it's another thing to FUCKING PREDICATE IT ON WIKIPEDIA PAGE CONTENT FORMATTING. Or, y'know make dumb-ass assumptions about filesystems that have zero bearing on the actual test result.

Good gracious dumpster fire of Node, why are you like this? Why do you just reinvent Java, badly, for "in 21-days" vibe programmers?