### PR TITLE
Chop out more dependency hell; make bump script less jank

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,11 +90,11 @@
         "jest": "",
         "playwright": "^1.36.2",
         "prettier": "^3.0.1",
-        "rimraf": "^5.0.1",
+        "rimraf": "",
         "ts-loader": "^9.4.4",
         "typescript": "^5.1.6",
         "webpack": "^5.88.2",
-        "webpack-cli": "^5.1.4"
+        "webpack-cli": ""
     },
     "overrides": {
         "axios": "$axios"


### PR DESCRIPTION
* We take latest rimraf and webpack-cli, both of which were outdated
* The script updates the semver and emits some handy output now